### PR TITLE
Styling account component in header to be more responsive

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -478,7 +478,37 @@ function App(props) {
 
   return (
     <div className="App">
-      <Header />
+      <Header>
+        {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
+        <div style={{ position: "relative" }}>
+          <div style={{ display: "flex", flex: 1, alignItems: "center", padding: "0.5rem 0" }}>
+            {USE_NETWORK_SELECTOR && (
+              <div style={{ marginRight: 20 }}>
+                <NetworkSwitch
+                  networkOptions={networkOptions}
+                  selectedNetwork={selectedNetwork}
+                  setSelectedNetwork={setSelectedNetwork}
+                />
+              </div>
+            )}
+            <Account
+              useBurner={USE_BURNER_WALLET}
+              address={address}
+              localProvider={localProvider}
+              userSigner={userSigner}
+              mainnetProvider={mainnetProvider}
+              price={price}
+              web3Modal={web3Modal}
+              loadWeb3Modal={loadWeb3Modal}
+              logoutOfWeb3Modal={logoutOfWeb3Modal}
+              blockExplorer={blockExplorer}
+            />
+          </div>
+          {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
+            <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
+          )}
+        </div>
+      </Header>
       <NetworkDisplay
         NETWORKCHECK={NETWORKCHECK}
         localChainId={localChainId}
@@ -648,36 +678,6 @@ function App(props) {
       </Switch>
 
       <ThemeSwitch />
-
-      {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
-      <div style={{ position: "fixed", textAlign: "right", right: 0, top: 0, padding: 10 }}>
-        <div style={{ display: "flex", flex: 1, alignItems: "center" }}>
-          {USE_NETWORK_SELECTOR && (
-            <div style={{ marginRight: 20 }}>
-              <NetworkSwitch
-                networkOptions={networkOptions}
-                selectedNetwork={selectedNetwork}
-                setSelectedNetwork={setSelectedNetwork}
-              />
-            </div>
-          )}
-          <Account
-            useBurner={USE_BURNER_WALLET}
-            address={address}
-            localProvider={localProvider}
-            userSigner={userSigner}
-            mainnetProvider={mainnetProvider}
-            price={price}
-            web3Modal={web3Modal}
-            loadWeb3Modal={loadWeb3Modal}
-            logoutOfWeb3Modal={logoutOfWeb3Modal}
-            blockExplorer={blockExplorer}
-          />
-        </div>
-        {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
-          <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
-        )}
-      </div>
 
       {/* 🗺 Extra UI like gas price, eth price, faucet, and support: */}
       <div style={{ position: "fixed", textAlign: "left", left: 0, bottom: 20, padding: 10 }}>

--- a/packages/react-app/src/components/Account.jsx
+++ b/packages/react-app/src/components/Account.jsx
@@ -58,85 +58,59 @@ export default function Account({
 }) {
   const { currentTheme } = useThemeSwitcher();
 
-  const modalButtons = [];
-  if (web3Modal) {
-    if (web3Modal.cachedProvider) {
-      modalButtons.push(
-        <Button
-          key="logoutbutton"
-          style={{ verticalAlign: "top", marginLeft: 8, marginTop: 4 }}
-          shape="round"
-          size="large"
-          onClick={logoutOfWeb3Modal}
-        >
-          logout
-        </Button>,
-      );
-    } else {
-      modalButtons.push(
-        <Button
-          key="loginbutton"
-          style={{ verticalAlign: "top", marginLeft: 8, marginTop: 4 }}
-          shape="round"
-          size="large"
-          /* type={minimized ? "default" : "primary"}     too many people just defaulting to MM and having a bad time */
-          onClick={loadWeb3Modal}
-        >
-          connect
-        </Button>,
-      );
-    }
+  let accountButton;
+  if (web3Modal?.cachedProvider) {
+    accountButton = { name: 'Logout', action: logoutOfWeb3Modal };
+  } else {
+    accountButton = { name: 'Connect', action: loadWeb3Modal };
   }
-  const display = minimized ? (
-    ""
-  ) : (
-    <span>
-      {web3Modal && web3Modal.cachedProvider ? (
-        <>
-          {address && <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />}
-          <Balance address={address} provider={localProvider} price={price} />
-          <Wallet
-            address={address}
-            provider={localProvider}
-            signer={userSigner}
-            ensProvider={mainnetProvider}
-            price={price}
-            color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
-          />
-        </>
-      ) : useBurner ? (
-        ""
-      ) : isContract ? (
-        <>
-          {address && <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />}
-          <Balance address={address} provider={localProvider} price={price} />
-        </>
-      ) : (
-        ""
-      )}
-      {useBurner && web3Modal && !web3Modal.cachedProvider ? (
-        <>
-          <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />
-          <Balance address={address} provider={localProvider} price={price} />
-          <Wallet
-            address={address}
-            provider={localProvider}
-            signer={userSigner}
-            ensProvider={mainnetProvider}
-            price={price}
-            color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
-          />
-        </>
-      ) : (
-        <></>
-      )}
-    </span>
-  );
 
   return (
-    <div>
-      {display}
-      {modalButtons}
+    <div style={{ display: "flex" }}>
+      <div style={{
+        border: "1px solid #d9d9d9",
+        borderRadius: "9999px",
+        paddingLeft: "0.875rem",
+        display: "flex",
+        alignItems: "center",
+      }}>
+        <Balance address={address} provider={localProvider} price={price} size={"1.125rem"} />
+        <Wallet
+          address={address}
+          provider={localProvider}
+          signer={userSigner}
+          ensProvider={mainnetProvider}
+          price={price}
+          color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
+          size={"1.4rem"}
+          padding={"0px"}
+        />
+        <div style={{
+          border: "1px solid transparent",
+          borderRadius: "9999px",
+          backgroundColor: currentTheme === "light" ? "#f1f5f9" : "#262626",
+          marginLeft: "0.5rem",
+          padding: "0.375rem 0.875rem",
+        }}>
+          {address && (
+            <Address
+              address={address}
+              ensProvider={mainnetProvider}
+              blockExplorer={blockExplorer}
+              fontSize={"1.125rem"}
+              blockieSize={5}
+            />
+          )}
+        </div>
+      </div>
+      <Button
+        style={{ verticalAlign: "top", marginLeft: 8, height: "auto" }}
+        shape="round"
+        size="large"
+        onClick={accountButton.action}
+      >
+        {accountButton.name}
+      </Button>
     </div>
   );
 }

--- a/packages/react-app/src/components/Address.jsx
+++ b/packages/react-app/src/components/Address.jsx
@@ -67,18 +67,16 @@ export default function Address(props) {
           href={etherscanLink}
           rel="noopener noreferrer"
         >
-          <Blockies seed={address.toLowerCase()} size={8} scale={2} />
+          <Blockies seed={address.toLowerCase()} size={props.blockieSize ? props.blockieSize : 8} scale={2} />
         </a>
       </span>
     );
   }
 
   return (
-    <span>
-      <span style={{ verticalAlign: "middle" }}>
-        <Blockies seed={address.toLowerCase()} size={8} scale={props.fontSize ? props.fontSize / 7 : 4} />
-      </span>
-      <span style={{ verticalAlign: "middle", paddingLeft: 5, fontSize: props.fontSize ? props.fontSize : 28 }}>
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <Blockies seed={address.toLowerCase()} size={props.blockieSize ? props.blockieSize : 8} scale={props.fontSize ? props.fontSize / 7 : 4} />
+      <span style={{paddingLeft: 5, fontSize: props.fontSize ? props.fontSize : 28 }}>
         {props.onChange ? (
           <Text editable={{ onChange: props.onChange }} copyable={{ text: address }}>
             <a
@@ -103,6 +101,6 @@ export default function Address(props) {
           </Text>
         )}
       </span>
-    </span>
+    </div>
   );
 }

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -78,7 +78,7 @@ export default function Balance(props) {
       style={{
         verticalAlign: "middle",
         fontSize: props.size ? props.size : 24,
-        padding: 8,
+        padding: "0 0.5rem",
         cursor: "pointer",
       }}
       onClick={() => {

--- a/packages/react-app/src/components/FaucetHint.jsx
+++ b/packages/react-app/src/components/FaucetHint.jsx
@@ -28,7 +28,7 @@ function FaucetHint({ localProvider, targetNetwork, address }) {
     ethers.utils.formatEther(yourLocalBalance) <= 0
   ) {
     faucetHint = (
-      <div style={{ padding: 16, display: "inline-flex" }}>
+      <div style={{ position: "absolute", left: 0, bottom: "-45px", padding: 16, display: "inline-flex" }}>
         <Button
           type="primary"
           onClick={() => {

--- a/packages/react-app/src/components/Header.jsx
+++ b/packages/react-app/src/components/Header.jsx
@@ -1,20 +1,18 @@
-import { PageHeader } from "antd";
 import React from "react";
+import { Typography } from "antd";
+
+const { Title } = Typography;
 
 // displays a page header
 
-export default function Header() {
+export default function Header(props) {
   return (
-    <a href="/">
-      <PageHeader
-        title="👛 multisig.lol"
-        subTitle={
-          <a href="https://github.com/austintgriffith/maas" target="_blank">
-            please fork this
-          </a>
-        }
-        style={{ cursor: "pointer" }}
-      />
-    </a>
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "0.5rem 1.2rem" }}>
+      <div style={{ display: "flex",  flex: 1, flexWrap: "wrap", alignItems: "center" }}>
+        <Title level={4} style={{ margin: "0 0.5rem 0 0" }}>👛 multisig.lol</Title>
+        <a href="https://github.com/austintgriffith/maas" target="_blank">please fork this</a>
+      </div>
+      {props.children}
+    </div>
   );
 }

--- a/packages/react-app/src/components/NetworkDisplay.jsx
+++ b/packages/react-app/src/components/NetworkDisplay.jsx
@@ -88,12 +88,6 @@ function NetworkDisplay({
         </div>
       );
     }
-  } else {
-    networkDisplay = USE_NETWORK_SELECTOR ? null : (
-      <div style={{ zIndex: -1, position: "absolute", right: 154, top: 28, padding: 16, color: targetNetwork.color }}>
-        {targetNetwork.name}
-      </div>
-    );
   }
 
   console.log({ networkDisplay });

--- a/packages/react-app/src/components/Wallet.jsx
+++ b/packages/react-app/src/components/Wallet.jsx
@@ -68,10 +68,10 @@ export default function Wallet(props) {
         }}
         rotate={-90}
         style={{
-          padding: 7,
+          padding: props.padding ? props.padding : 7,
           color: props.color ? props.color : "",
           cursor: "pointer",
-          fontSize: 28,
+          fontSize: props.size ? props.size : 28,
           verticalAlign: "middle",
         }}
       />
@@ -295,11 +295,9 @@ export default function Wallet(props) {
       <Modal
         visible={open}
         title={
-          <div>
+          <div style={{  display: "flex", alignItems: "center", justifyContent: "space-around" }}>
             {selectedAddress ? <Address address={selectedAddress} ensProvider={props.ensProvider} /> : <Spin />}
-            <div style={{ float: "right", paddingRight: 25 }}>
-              <Balance address={selectedAddress} provider={props.provider} dollarMultiplier={props.price} />
-            </div>
+            <Balance address={selectedAddress} provider={props.provider} dollarMultiplier={props.price} />
           </div>
         }
         onOk={() => {

--- a/packages/react-app/src/views/Home.jsx
+++ b/packages/react-app/src/views/Home.jsx
@@ -37,7 +37,7 @@ export default function Home({
               imageSettings={{ excavate: false }}
             />
           </div>
-          <div>
+          <div style={{ display: "flex", justifyContent: "center" }}>
             <Address
               address={contractAddress ? contractAddress : ""}
               ensProvider={mainnetProvider}


### PR DESCRIPTION
### What is this solving?

Currently the balance and address (in the `Account` component) overlap with the logo on smaller screens.

<img width="416" alt="image" src="https://user-images.githubusercontent.com/12888080/167280268-c0e7fc86-56dc-4a96-8eb3-3879d1871f35.png">

This PR adds responsive styling to the `Account` component to improve the UI on smaller screens.

<img width="417" alt="image" src="https://user-images.githubusercontent.com/12888080/167280291-d31a1d64-9973-444c-9bcb-01e4bf84874e.png">
<img width="449" alt="image" src="https://user-images.githubusercontent.com/12888080/167280315-06531f3b-1044-4528-81a9-2d13d63a1deb.png">
<img width="442" alt="image" src="https://user-images.githubusercontent.com/12888080/167280325-a54dff0a-3d11-4169-bcf6-67508fb38a61.png">

I removed the `targetNetwork.name` in `NetworkDisplay` as it is redundant information since we added the network switcher by the create multisig button (which essentially acts as displaying what the current selected network is).
<img width="237" alt="image" src="https://user-images.githubusercontent.com/12888080/167280456-f474a928-b5f9-464a-a88d-3135417d6f80.png">
