### PR TITLE
Import multisigs to localstorage

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -25,6 +25,7 @@ import {
   FaucetHint,
   NetworkSwitch,
   CreateMultiSigModal,
+  ImportMultiSigModal,
 } from "./components";
 import { NETWORKS, ALCHEMY_KEY } from "./constants";
 import externalContracts from "./contracts/external_contracts";
@@ -32,8 +33,8 @@ import externalContracts from "./contracts/external_contracts";
 // contracts
 import deployedContracts from "./contracts/hardhat_contracts.json";
 import { Transactor, Web3ModalSetup } from "./helpers";
-import { Home, ExampleUI, Hints, Subgraph, CreateTransaction, Transactions } from "./views";
-import { useStaticJsonRPC } from "./hooks";
+import { Home, Hints, Subgraph, CreateTransaction, Transactions } from "./views";
+import { useStaticJsonRPC, useLocalStorage } from "./hooks";
 
 const { Option } = Select;
 const { ethers } = require("ethers");
@@ -303,6 +304,8 @@ function App(props) {
   const [multiSigs, setMultiSigs] = useState([]);
   const [currentMultiSigAddress, setCurrentMultiSigAddress] = useState();
 
+  const [importedMultiSigs] = useLocalStorage("importedMultiSigs");
+
   /*
     if you want to hardcode a specific multisig for the frontend for everyone:
   useEffect(()=>{
@@ -314,13 +317,17 @@ function App(props) {
 
   useEffect(() => {
     if (address) {
-      const multiSigsForUser = ownersMultiSigEvents.reduce((filtered, createEvent) => {
+      let multiSigsForUser = ownersMultiSigEvents.reduce((filtered, createEvent) => {
         if (createEvent.args.owners.includes(address) && !filtered.includes(createEvent.args.contractAddress)) {
           filtered.push(createEvent.args.contractAddress);
         }
 
         return filtered;
       }, []);
+
+      if (importedMultiSigs && importedMultiSigs[targetNetwork.name]) {
+        multiSigsForUser = [...new Set([...importedMultiSigs[targetNetwork.name], ...multiSigsForUser])];
+      }
 
       if (multiSigsForUser.length > 0) {
         const recentMultiSigAddress = multiSigsForUser[multiSigsForUser.length - 1];
@@ -450,9 +457,9 @@ function App(props) {
 
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
 
-  const options = [];
+  const selectNetworkOptions = [];
   for (const id in NETWORKS) {
-    options.push(
+    selectNetworkOptions.push(
       <Select.Option key={id} value={NETWORKS[id].name}>
         <span style={{ color: NETWORKS[id].color }}>{NETWORKS[id].name}</span>
       </Select.Option>,
@@ -472,7 +479,7 @@ function App(props) {
         }
       }}
     >
-      {options}
+      {selectNetworkOptions}
     </Select>
   );
 
@@ -488,26 +495,38 @@ function App(props) {
         USE_NETWORK_SELECTOR={USE_NETWORK_SELECTOR}
       />
       <div style={{ position: "relative" }}>
-        <div style={{ position: "absolute", left: 20 }}>
-          <CreateMultiSigModal
-            price={price}
-            selectedChainId={selectedChainId}
+        <div style={{ position: "absolute", left: 20, display: "flex", flexDirection: "column", alignItems: "start" }}>
+          <div>
+            <CreateMultiSigModal
+              price={price}
+              selectedChainId={selectedChainId}
+              mainnetProvider={mainnetProvider}
+              address={address}
+              tx={tx}
+              writeContracts={writeContracts}
+              contractName={"MultiSigFactory"}
+              isCreateModalVisible={isCreateModalVisible}
+              setIsCreateModalVisible={setIsCreateModalVisible}
+            />
+            <Select value={[currentMultiSigAddress]} style={{ width: 120, marginRight: 5, }} onChange={handleMultiSigChange}>
+              {multiSigs.map((address, index) => (
+                <Option key={index} value={address}>
+                  {address}
+                </Option>
+              ))}
+            </Select>
+            {networkSelect}
+          </div>
+          <ImportMultiSigModal
             mainnetProvider={mainnetProvider}
-            address={address}
-            tx={tx}
-            writeContracts={writeContracts}
-            contractName={"MultiSigFactory"}
-            isCreateModalVisible={isCreateModalVisible}
-            setIsCreateModalVisible={setIsCreateModalVisible}
+            targetNetwork={targetNetwork}
+            networkOptions={selectNetworkOptions}
+            multiSigs={multiSigs}
+            setMultiSigs={setMultiSigs}
+            setCurrentMultiSigAddress={setCurrentMultiSigAddress}
+            multiSigWalletABI={multiSigWalletABI}
+            localProvider={localProvider}
           />
-          <Select value={[currentMultiSigAddress]} style={{ width: 120 }} onChange={handleMultiSigChange}>
-            {multiSigs.map((address, index) => (
-              <Option key={index} value={address}>
-                {address}
-              </Option>
-            ))}
-          </Select>
-          {networkSelect}
         </div>
       </div>
       <Menu

--- a/packages/react-app/src/components/MultiSig/ImportMultiSigModal.jsx
+++ b/packages/react-app/src/components/MultiSig/ImportMultiSigModal.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+import { Button, Modal, Select, Alert } from "antd";
+import { ethers } from "ethers";
+import { useLocalStorage } from "../../hooks";
+
+import { AddressInput } from "..";
+
+export default function ImportMultiSigModal({
+  mainnetProvider,
+  targetNetwork,
+  networkOptions,
+  multiSigs,
+  setMultiSigs,
+  setCurrentMultiSigAddress,
+  multiSigWalletABI,
+  localProvider,
+}) {
+  const [importedMultiSigs, setImportedMultiSigs] = useLocalStorage("importedMultiSigs");
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [pendingImport, setPendingImport] = useState(false);
+  const [error, setError] = useState(false);
+  const [address, setAddress] = useState();
+  const [network, setNetwork] = useState(targetNetwork.name);
+
+  const resetState = () => {
+    setError(false);
+    setAddress("");
+    setNetwork(targetNetwork.name);
+    setPendingImport(false);
+  };
+
+  const handleCancel = () => {
+    resetState();
+    setIsModalVisible(false);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      setPendingImport(true);
+
+      const contract = new ethers.Contract(address, multiSigWalletABI, localProvider);
+      await contract.signaturesRequired();
+
+      let newImportedMultiSigs = importedMultiSigs || {};
+      (newImportedMultiSigs[network] = newImportedMultiSigs[network] || []).push(address);
+      newImportedMultiSigs[network] = [...new Set(newImportedMultiSigs[network])];
+      setImportedMultiSigs(newImportedMultiSigs);
+
+      if (network === targetNetwork.name) {
+        setMultiSigs([...new Set([...newImportedMultiSigs[network], ...multiSigs])]);
+        setCurrentMultiSigAddress(address);
+      }
+
+      resetState();
+      setIsModalVisible(false);
+    } catch(e) {
+      console.log("Import error:", e);
+      setError(true);
+      setPendingImport(false);
+    }
+  };
+
+  return (
+    <>
+      <Button type="link" onClick={ () => setIsModalVisible(true) }>Import</Button>
+      <Modal
+        title="Import Multisig"
+        visible={isModalVisible}
+        onCancel={handleCancel}
+        destroyOnClose
+        footer={[
+          <Button key="back" onClick={handleCancel}>
+            Cancel
+          </Button>,
+          <Button
+            key="submit"
+            type="primary"
+            disabled={!address || !network}
+            loading={pendingImport}
+            onClick={handleSubmit}
+          >
+            Import
+          </Button>,
+        ]}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <AddressInput
+            autoFocus
+            ensProvider={mainnetProvider}
+            placeholder={"Multisig address"}
+            value={address}
+            onChange={setAddress}
+          />
+          <Select
+            defaultValue={targetNetwork.name}
+            onChange={ value => setNetwork(value) }
+          >
+            {networkOptions}
+          </Select>
+          { error && <Alert message="Unable to import: this doesn't seem like a multisig." type="error" showIcon /> }
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/packages/react-app/src/components/index.js
+++ b/packages/react-app/src/components/index.js
@@ -28,3 +28,4 @@ export { default as WalletConnectInput } from "./WalletConnectInput";
 export { default as TransactionListItem } from "./MultiSig/TransactionListItem";
 export { default as Owners } from "./MultiSig/Owners";
 export { default as CreateMultiSigModal } from "./MultiSig/CreateMultiSigModal";
+export { default as ImportMultiSigModal } from "./MultiSig/ImportMultiSigModal";


### PR DESCRIPTION
### What is this solving?

This PR adds the ability to import multsigs to `localstorage`. The available multisigs are then the user's created multisigs via the multsig factory and what is stored in `localstorage`.

The import validation reads the `signaturesRequired` variable on the provided contract address. If reading this variable fails, we throw and error as we are unable to determine that it is an multsig.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/12888080/167778776-58e75dd7-6885-459e-9665-71bb4e8d92eb.png">

<img width="573" alt="image" src="https://user-images.githubusercontent.com/12888080/167778848-d3228a4d-9da3-404f-97d4-6f2546f13535.png">

<img width="560" alt="image" src="https://user-images.githubusercontent.com/12888080/167778920-3ee4af54-158d-4aae-b5a0-c0b2befa04ac.png">
