### PR TITLE
Reducing renders of transaction list items to prevent re-rendering issues

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -384,11 +384,16 @@ function App(props) {
   const [executeTransactionEvents, setExecuteTransactionEvents] = useState();
 
   useEffect(() => {
-    setExecuteTransactionEvents(
-      allExecuteTransactionEvents.filter(contractEvent => contractEvent.address === currentMultiSigAddress).reverse(),
-    );
     setOwnerEvents(allOwnerEvents.filter(contractEvent => contractEvent.address === currentMultiSigAddress));
-  }, [allExecuteTransactionEvents, allOwnerEvents, currentMultiSigAddress]);
+  }, [allOwnerEvents, currentMultiSigAddress]);
+
+  useEffect(() => {
+    const filteredEvents = allExecuteTransactionEvents.filter(contractEvent => contractEvent.address === currentMultiSigAddress);
+    const nonceNum = typeof(nonce) === "number" ? nonce : nonce?.toNumber();
+    if (nonceNum === filteredEvents.length) {
+      setExecuteTransactionEvents(filteredEvents.reverse());
+    }
+  }, [allExecuteTransactionEvents, currentMultiSigAddress, nonce]);
 
   // EXTERNAL CONTRACT EXAMPLE:
   // If you want to bring in the mainnet DAI contract it would look like:

--- a/packages/react-app/src/views/Home.jsx
+++ b/packages/react-app/src/views/Home.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Balance, Address, TransactionListItem, Owners } from "../components";
 import QR from "qrcode.react";
-import { List, Row, Col, Button } from "antd";
+import { List, Button } from "antd";
 
 export default function Home({
   contractAddress,
@@ -58,7 +58,6 @@ export default function Home({
           bordered
           dataSource={executeTransactionEvents}
           renderItem={item => {
-            //console.log("RENDERING ITEM",item)
             return (
               <TransactionListItem
                 item={Object.create(item)}


### PR DESCRIPTION
### What is this solving?

The transaction list that displays the `executeTransactionEvents` was experiencing UI issues, especially when there are many events.

In the first few seconds, the transaction list items would render correctly, like item `#38` here:
<img width="994" alt="image" src="https://user-images.githubusercontent.com/12888080/168459457-d793716b-e4bb-4c43-91c0-281141d9535f.png">

However, after a moment a re-render occurs causing the correct data to change as if the transaction data was not found:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/12888080/168459493-78b2698f-b72e-4af2-b6f2-5a69b30c1994.png">

Oddly, this problem **does not occur** if `executeTransactionEvents` are not rendered in reverse. I suspect the `List` component we are using is acting buggy due to the many state changes as `executeTransactionEvents` is hydrated and then also when the list items return the async data of external contract calls.

**tl;dr I suspect the many renders occurring due to the changes of `executeTransactionEvents` and waiting on other calls in the list items is causing the issue.**

### The Fix

This PR improves the statefulness of the `List` in our `Home` component by only setting `executeTransactionEvents` when the events size matches the current `nonce`. For example, if our contract is on `nonce` 5 and this means we would expect there to be 5 events.

By only setting `executeTransactionEvents` when we finally have all the events retrieved, our state changes to the list are less erratic which fixes the issue!