### PR TITLE
feat: P2P Transaction Proposal

### DIFF
--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -44,6 +44,7 @@
     "ipfs-http-client": "^55.0.0",
     "isomorphic-fetch": "^3.0.0",
     "node-watch": "^0.7.1",
+    "peerjs": "1.4.4",
     "postcss": "^8.2.6",
     "qrcode.react": "^1.0.0",
     "react": "^17.0.2",

--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -54,6 +54,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "searchico": "^1.2.1",
+    "swr": "1.3.0",
     "walletlink": "^2.1.5",
     "web3modal": "^1.9.1"
   },

--- a/packages/react-app/package.json
+++ b/packages/react-app/package.json
@@ -44,7 +44,7 @@
     "ipfs-http-client": "^55.0.0",
     "isomorphic-fetch": "^3.0.0",
     "node-watch": "^0.7.1",
-    "peerjs": "1.4.4",
+    "peerjs": "1.3.2",
     "postcss": "^8.2.6",
     "qrcode.react": "^1.0.0",
     "react": "^17.0.2",

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -12,6 +12,7 @@ import { useExchangeEthPrice } from "eth-hooks/dapps/dex";
 import { useEventListener } from "eth-hooks/events/";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, Route, Switch, useLocation } from "react-router-dom";
+import { TransactionsProvider } from "./contexts";
 import "./App.css";
 import {
   Account,
@@ -586,107 +587,113 @@ function App(props) {
           <Link to="/pool">Pool</Link>
         </Menu.Item>
       </Menu>
-
-      <Switch>
-        <Route exact path="/">
-          {!userHasMultiSigs ? (
-            <Row style={{ marginTop: 40 }}>
-              <Col span={12} offset={6}>
-                <Alert
-                  message={
-                    <>
-                      ✨{" "}
-                      <Button onClick={() => setIsCreateModalVisible(true)} type="link" style={{ padding: 0 }}>
-                        Create
-                      </Button>{" "}
-                      or select your Multi-Sig ✨
-                    </>
-                  }
-                  type="info"
-                />
-              </Col>
-            </Row>
-          ) : (
-            <Home
-              contractAddress={currentMultiSigAddress}
+      <TransactionsProvider
+        providerType="server"
+        providerOptions={{
+          url: BACKEND_URL + readContracts[contractName].address + "_" + localProvider._network.chainId,
+          address,
+          contractAddress,
+          ownerEvents,
+        }}
+      >
+        <Switch>
+          <Route exact path="/">
+            {!userHasMultiSigs ? (
+              <Row style={{ marginTop: 40 }}>
+                <Col span={12} offset={6}>
+                  <Alert
+                    message={
+                      <>
+                        ✨{" "}
+                        <Button onClick={() => setIsCreateModalVisible(true)} type="link" style={{ padding: 0 }}>
+                          Create
+                        </Button>{" "}
+                        or select your Multi-Sig ✨
+                      </>
+                    }
+                    type="info"
+                  />
+                </Col>
+              </Row>
+            ) : (
+              <Home
+                contractAddress={currentMultiSigAddress}
+                localProvider={localProvider}
+                price={price}
+                mainnetProvider={mainnetProvider}
+                blockExplorer={blockExplorer}
+                executeTransactionEvents={executeTransactionEvents}
+                contractName={contractName}
+                readContracts={readContracts}
+                ownerEvents={ownerEvents}
+                signaturesRequired={signaturesRequired}
+              />
+            )}
+          </Route>
+          <Route path="/create">
+            <CreateTransaction
+              contractName={contractName}
+              contractAddress={contractAddress}
+              mainnetProvider={mainnetProvider}
               localProvider={localProvider}
               price={price}
-              mainnetProvider={mainnetProvider}
-              blockExplorer={blockExplorer}
-              executeTransactionEvents={executeTransactionEvents}
-              contractName={contractName}
+              tx={tx}
               readContracts={readContracts}
-              ownerEvents={ownerEvents}
+              userSigner={userSigner}
+              DEBUG={DEBUG}
+              nonce={nonce}
+              blockExplorer={blockExplorer}
               signaturesRequired={signaturesRequired}
             />
-          )}
-        </Route>
-        <Route path="/create">
-          <CreateTransaction
-            poolServerUrl={BACKEND_URL}
-            contractName={contractName}
-            contractAddress={contractAddress}
-            mainnetProvider={mainnetProvider}
-            localProvider={localProvider}
-            price={price}
-            tx={tx}
-            readContracts={readContracts}
-            userSigner={userSigner}
-            DEBUG={DEBUG}
-            nonce={nonce}
-            blockExplorer={blockExplorer}
-            signaturesRequired={signaturesRequired}
-          />
-        </Route>
-        <Route path="/pool">
-          <Transactions
-            poolServerUrl={BACKEND_URL}
-            contractName={contractName}
-            address={address}
-            userSigner={userSigner}
-            mainnetProvider={mainnetProvider}
-            localProvider={localProvider}
-            yourLocalBalance={yourLocalBalance}
-            price={price}
-            tx={tx}
-            writeContracts={writeContracts}
-            readContracts={readContracts}
-            blockExplorer={blockExplorer}
-            nonce={nonce}
-            signaturesRequired={signaturesRequired}
-          />
-        </Route>
-        <Route exact path="/debug">
-          <Contract
-            name={"MultiSigFactory"}
-            price={price}
-            signer={userSigner}
-            provider={localProvider}
-            address={address}
-            blockExplorer={blockExplorer}
-            contractConfig={contractConfig}
-          />
-        </Route>
-        <Route path="/hints">
-          <Hints
-            address={address}
-            yourLocalBalance={yourLocalBalance}
-            mainnetProvider={mainnetProvider}
-            price={price}
-          />
-        </Route>
-        <Route path="/mainnetdai">
-          <Contract
-            name="DAI"
-            customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.DAI}
-            signer={userSigner}
-            provider={mainnetProvider}
-            address={address}
-            blockExplorer="https://etherscan.io/"
-            contractConfig={contractConfig}
-            chainId={1}
-          />
-          {/*
+          </Route>
+          <Route path="/pool">
+            <Transactions
+              contractName={contractName}
+              address={address}
+              userSigner={userSigner}
+              mainnetProvider={mainnetProvider}
+              localProvider={localProvider}
+              yourLocalBalance={yourLocalBalance}
+              price={price}
+              tx={tx}
+              writeContracts={writeContracts}
+              readContracts={readContracts}
+              blockExplorer={blockExplorer}
+              nonce={nonce}
+              signaturesRequired={signaturesRequired}
+            />
+          </Route>
+          <Route exact path="/debug">
+            <Contract
+              name={"MultiSigFactory"}
+              price={price}
+              signer={userSigner}
+              provider={localProvider}
+              address={address}
+              blockExplorer={blockExplorer}
+              contractConfig={contractConfig}
+            />
+          </Route>
+          <Route path="/hints">
+            <Hints
+              address={address}
+              yourLocalBalance={yourLocalBalance}
+              mainnetProvider={mainnetProvider}
+              price={price}
+            />
+          </Route>
+          <Route path="/mainnetdai">
+            <Contract
+              name="DAI"
+              customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.DAI}
+              signer={userSigner}
+              provider={mainnetProvider}
+              address={address}
+              blockExplorer="https://etherscan.io/"
+              contractConfig={contractConfig}
+              chainId={1}
+            />
+            {/*
             <Contract
               name="UNI"
               customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.UNI}
@@ -696,16 +703,17 @@ function App(props) {
               blockExplorer="https://etherscan.io/"
             />
             */}
-        </Route>
-        <Route path="/subgraph">
-          <Subgraph
-            subgraphUri={props.subgraphUri}
-            tx={tx}
-            writeContracts={writeContracts}
-            mainnetProvider={mainnetProvider}
-          />
-        </Route>
-      </Switch>
+          </Route>
+          <Route path="/subgraph">
+            <Subgraph
+              subgraphUri={props.subgraphUri}
+              tx={tx}
+              writeContracts={writeContracts}
+              mainnetProvider={mainnetProvider}
+            />
+          </Route>
+        </Switch>
+      </TransactionsProvider>
 
       <ThemeSwitch />
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -12,6 +12,7 @@ import { useExchangeEthPrice } from "eth-hooks/dapps/dex";
 import { useEventListener } from "eth-hooks/events/";
 import React, { useCallback, useEffect, useState } from "react";
 import { Link, Route, Switch, useLocation } from "react-router-dom";
+import { ServerBasedTransactionsProvider } from "./contexts";
 import "./App.css";
 import {
   Account,
@@ -218,7 +219,7 @@ function App(props) {
     BACKEND_URL = "https://backend.multisig.lol:49899/";
   }
 
-  if(!targetNetwork) targetNetwork = NETWORKS["localhost"];
+  if (!targetNetwork) targetNetwork = NETWORKS["localhost"];
 
   // 🔭 block explorer URL
   const blockExplorer = targetNetwork.blockExplorer;
@@ -476,157 +477,162 @@ function App(props) {
     </Select>
   );
 
-  return (
-    <div className="App">
-      <Header />
-      <NetworkDisplay
-        NETWORKCHECK={NETWORKCHECK}
-        localChainId={localChainId}
-        selectedChainId={selectedChainId}
-        targetNetwork={targetNetwork}
-        logoutOfWeb3Modal={logoutOfWeb3Modal}
-        USE_NETWORK_SELECTOR={USE_NETWORK_SELECTOR}
-      />
-      <div style={{ position: "relative" }}>
-        <div style={{ position: "absolute", left: 20 }}>
-          <CreateMultiSigModal
-            price={price}
-            selectedChainId={selectedChainId}
-            mainnetProvider={mainnetProvider}
-            address={address}
-            tx={tx}
-            writeContracts={writeContracts}
-            contractName={"MultiSigFactory"}
-            isCreateModalVisible={isCreateModalVisible}
-            setIsCreateModalVisible={setIsCreateModalVisible}
-          />
-          <Select value={[currentMultiSigAddress]} style={{ width: 120 }} onChange={handleMultiSigChange}>
-            {multiSigs.map((address, index) => (
-              <Option key={index} value={address}>
-                {address}
-              </Option>
-            ))}
-          </Select>
-          {networkSelect}
-        </div>
-      </div>
-      <Menu
-        disabled={!userHasMultiSigs}
-        style={{ textAlign: "center", marginTop: 40 }}
-        selectedKeys={[location.pathname]}
-        mode="horizontal"
-      >
-        <Menu.Item key="/">
-          <Link to="/">MultiSig</Link>
-        </Menu.Item>
-        <Menu.Item key="/create">
-          <Link to="/create">Propose Transaction</Link>
-        </Menu.Item>
-        <Menu.Item key="/pool">
-          <Link to="/pool">Pool</Link>
-        </Menu.Item>
-      </Menu>
+  const backendUrl =
+    readContracts[contractName] && localProvider
+      ? BACKEND_URL + readContracts[contractName].address + "_" + localProvider._network.chainId
+      : null;
 
-      <Switch>
-        <Route exact path="/">
-          {!userHasMultiSigs ? (
-            <Row style={{ marginTop: 40 }}>
-              <Col span={12} offset={6}>
-                <Alert
-                  message={
-                    <>
-                      ✨{" "}
-                      <Button onClick={() => setIsCreateModalVisible(true)} type="link" style={{ padding: 0 }}>
-                        Create
-                      </Button>{" "}
-                      or select your Multi-Sig ✨
-                    </>
-                  }
-                  type="info"
-                />
-              </Col>
-            </Row>
-          ) : (
-            <Home
-              contractAddress={currentMultiSigAddress}
+  return (
+    <ServerBasedTransactionsProvider url={backendUrl}>
+      <div className="App">
+        <Header />
+        <NetworkDisplay
+          NETWORKCHECK={NETWORKCHECK}
+          localChainId={localChainId}
+          selectedChainId={selectedChainId}
+          targetNetwork={targetNetwork}
+          logoutOfWeb3Modal={logoutOfWeb3Modal}
+          USE_NETWORK_SELECTOR={USE_NETWORK_SELECTOR}
+        />
+        <div style={{ position: "relative" }}>
+          <div style={{ position: "absolute", left: 20 }}>
+            <CreateMultiSigModal
+              price={price}
+              selectedChainId={selectedChainId}
+              mainnetProvider={mainnetProvider}
+              address={address}
+              tx={tx}
+              writeContracts={writeContracts}
+              contractName={"MultiSigFactory"}
+              isCreateModalVisible={isCreateModalVisible}
+              setIsCreateModalVisible={setIsCreateModalVisible}
+            />
+            <Select value={[currentMultiSigAddress]} style={{ width: 120 }} onChange={handleMultiSigChange}>
+              {multiSigs.map((address, index) => (
+                <Option key={index} value={address}>
+                  {address}
+                </Option>
+              ))}
+            </Select>
+            {networkSelect}
+          </div>
+        </div>
+        <Menu
+          disabled={!userHasMultiSigs}
+          style={{ textAlign: "center", marginTop: 40 }}
+          selectedKeys={[location.pathname]}
+          mode="horizontal"
+        >
+          <Menu.Item key="/">
+            <Link to="/">MultiSig</Link>
+          </Menu.Item>
+          <Menu.Item key="/create">
+            <Link to="/create">Propose Transaction</Link>
+          </Menu.Item>
+          <Menu.Item key="/pool">
+            <Link to="/pool">Pool</Link>
+          </Menu.Item>
+        </Menu>
+
+        <Switch>
+          <Route exact path="/">
+            {!userHasMultiSigs ? (
+              <Row style={{ marginTop: 40 }}>
+                <Col span={12} offset={6}>
+                  <Alert
+                    message={
+                      <>
+                        ✨{" "}
+                        <Button onClick={() => setIsCreateModalVisible(true)} type="link" style={{ padding: 0 }}>
+                          Create
+                        </Button>{" "}
+                        or select your Multi-Sig ✨
+                      </>
+                    }
+                    type="info"
+                  />
+                </Col>
+              </Row>
+            ) : (
+              <Home
+                contractAddress={currentMultiSigAddress}
+                localProvider={localProvider}
+                price={price}
+                mainnetProvider={mainnetProvider}
+                blockExplorer={blockExplorer}
+                executeTransactionEvents={executeTransactionEvents}
+                contractName={contractName}
+                readContracts={readContracts}
+                ownerEvents={ownerEvents}
+                signaturesRequired={signaturesRequired}
+              />
+            )}
+          </Route>
+          <Route path="/create">
+            <CreateTransaction
+              poolServerUrl={BACKEND_URL}
+              contractName={contractName}
+              contractAddress={contractAddress}
+              mainnetProvider={mainnetProvider}
               localProvider={localProvider}
               price={price}
-              mainnetProvider={mainnetProvider}
-              blockExplorer={blockExplorer}
-              executeTransactionEvents={executeTransactionEvents}
-              contractName={contractName}
+              tx={tx}
               readContracts={readContracts}
-              ownerEvents={ownerEvents}
+              userSigner={userSigner}
+              DEBUG={DEBUG}
+              nonce={nonce}
+              blockExplorer={blockExplorer}
               signaturesRequired={signaturesRequired}
             />
-          )}
-        </Route>
-        <Route path="/create">
-          <CreateTransaction
-            poolServerUrl={BACKEND_URL}
-            contractName={contractName}
-            contractAddress={contractAddress}
-            mainnetProvider={mainnetProvider}
-            localProvider={localProvider}
-            price={price}
-            tx={tx}
-            readContracts={readContracts}
-            userSigner={userSigner}
-            DEBUG={DEBUG}
-            nonce={nonce}
-            blockExplorer={blockExplorer}
-            signaturesRequired={signaturesRequired}
-          />
-        </Route>
-        <Route path="/pool">
-          <Transactions
-            poolServerUrl={BACKEND_URL}
-            contractName={contractName}
-            address={address}
-            userSigner={userSigner}
-            mainnetProvider={mainnetProvider}
-            localProvider={localProvider}
-            yourLocalBalance={yourLocalBalance}
-            price={price}
-            tx={tx}
-            writeContracts={writeContracts}
-            readContracts={readContracts}
-            blockExplorer={blockExplorer}
-            nonce={nonce}
-            signaturesRequired={signaturesRequired}
-          />
-        </Route>
-        <Route exact path="/debug">
-          <Contract
-            name={"MultiSigFactory"}
-            price={price}
-            signer={userSigner}
-            provider={localProvider}
-            address={address}
-            blockExplorer={blockExplorer}
-            contractConfig={contractConfig}
-          />
-        </Route>
-        <Route path="/hints">
-          <Hints
-            address={address}
-            yourLocalBalance={yourLocalBalance}
-            mainnetProvider={mainnetProvider}
-            price={price}
-          />
-        </Route>
-        <Route path="/mainnetdai">
-          <Contract
-            name="DAI"
-            customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.DAI}
-            signer={userSigner}
-            provider={mainnetProvider}
-            address={address}
-            blockExplorer="https://etherscan.io/"
-            contractConfig={contractConfig}
-            chainId={1}
-          />
-          {/*
+          </Route>
+          <Route path="/pool">
+            <Transactions
+              contractName={contractName}
+              address={address}
+              userSigner={userSigner}
+              mainnetProvider={mainnetProvider}
+              localProvider={localProvider}
+              yourLocalBalance={yourLocalBalance}
+              price={price}
+              tx={tx}
+              writeContracts={writeContracts}
+              readContracts={readContracts}
+              blockExplorer={blockExplorer}
+              nonce={nonce}
+              signaturesRequired={signaturesRequired}
+            />
+          </Route>
+          <Route exact path="/debug">
+            <Contract
+              name={"MultiSigFactory"}
+              price={price}
+              signer={userSigner}
+              provider={localProvider}
+              address={address}
+              blockExplorer={blockExplorer}
+              contractConfig={contractConfig}
+            />
+          </Route>
+          <Route path="/hints">
+            <Hints
+              address={address}
+              yourLocalBalance={yourLocalBalance}
+              mainnetProvider={mainnetProvider}
+              price={price}
+            />
+          </Route>
+          <Route path="/mainnetdai">
+            <Contract
+              name="DAI"
+              customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.DAI}
+              signer={userSigner}
+              provider={mainnetProvider}
+              address={address}
+              blockExplorer="https://etherscan.io/"
+              contractConfig={contractConfig}
+              chainId={1}
+            />
+            {/*
             <Contract
               name="UNI"
               customContract={mainnetContracts && mainnetContracts.contracts && mainnetContracts.contracts.UNI}
@@ -636,89 +642,90 @@ function App(props) {
               blockExplorer="https://etherscan.io/"
             />
             */}
-        </Route>
-        <Route path="/subgraph">
-          <Subgraph
-            subgraphUri={props.subgraphUri}
-            tx={tx}
-            writeContracts={writeContracts}
-            mainnetProvider={mainnetProvider}
-          />
-        </Route>
-      </Switch>
+          </Route>
+          <Route path="/subgraph">
+            <Subgraph
+              subgraphUri={props.subgraphUri}
+              tx={tx}
+              writeContracts={writeContracts}
+              mainnetProvider={mainnetProvider}
+            />
+          </Route>
+        </Switch>
 
-      <ThemeSwitch />
+        <ThemeSwitch />
 
-      {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
-      <div style={{ position: "fixed", textAlign: "right", right: 0, top: 0, padding: 10 }}>
-        <div style={{ display: "flex", flex: 1, alignItems: "center" }}>
-          {USE_NETWORK_SELECTOR && (
-            <div style={{ marginRight: 20 }}>
-              <NetworkSwitch
-                networkOptions={networkOptions}
-                selectedNetwork={selectedNetwork}
-                setSelectedNetwork={setSelectedNetwork}
-              />
-            </div>
+        {/* 👨‍💼 Your account is in the top right with a wallet at connect options */}
+        <div style={{ position: "fixed", textAlign: "right", right: 0, top: 0, padding: 10 }}>
+          <div style={{ display: "flex", flex: 1, alignItems: "center" }}>
+            {USE_NETWORK_SELECTOR && (
+              <div style={{ marginRight: 20 }}>
+                <NetworkSwitch
+                  networkOptions={networkOptions}
+                  selectedNetwork={selectedNetwork}
+                  setSelectedNetwork={setSelectedNetwork}
+                />
+              </div>
+            )}
+            <Account
+              useBurner={USE_BURNER_WALLET}
+              address={address}
+              localProvider={localProvider}
+              userSigner={userSigner}
+              mainnetProvider={mainnetProvider}
+              price={price}
+              web3Modal={web3Modal}
+              loadWeb3Modal={loadWeb3Modal}
+              logoutOfWeb3Modal={logoutOfWeb3Modal}
+              blockExplorer={blockExplorer}
+            />
+          </div>
+          {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
+            <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
           )}
-          <Account
-            useBurner={USE_BURNER_WALLET}
-            address={address}
-            localProvider={localProvider}
-            userSigner={userSigner}
-            mainnetProvider={mainnetProvider}
-            price={price}
-            web3Modal={web3Modal}
-            loadWeb3Modal={loadWeb3Modal}
-            logoutOfWeb3Modal={logoutOfWeb3Modal}
-            blockExplorer={blockExplorer}
-          />
         </div>
-        {yourLocalBalance.lte(ethers.BigNumber.from("0")) && (
-          <FaucetHint localProvider={localProvider} targetNetwork={targetNetwork} address={address} />
-        )}
+
+        {/* 🗺 Extra UI like gas price, eth price, faucet, and support: */}
+        <div style={{ position: "fixed", textAlign: "left", left: 0, bottom: 20, padding: 10 }}>
+          <Row align="middle" gutter={[4, 4]}>
+            <Col span={8}>
+              <Ramp price={price} address={address} networks={NETWORKS} />
+            </Col>
+
+            <Col span={8} style={{ textAlign: "center", opacity: 0.8 }}>
+              <GasGauge gasPrice={gasPrice} />
+            </Col>
+            <Col span={8} style={{ textAlign: "center", opacity: 1 }}>
+              <Button
+                onClick={() => {
+                  window.open("https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA");
+                }}
+                size="large"
+                shape="round"
+              >
+                <span style={{ marginRight: 8 }} role="img" aria-label="support">
+                  💬
+                </span>
+                Support
+              </Button>
+            </Col>
+          </Row>
+
+          <Row align="middle" gutter={[4, 4]}>
+            <Col span={24}>
+              {
+                /*  if the local provider has a signer, let's show the faucet:  */
+                faucetAvailable ? (
+                  <Faucet localProvider={localProvider} price={price} ensProvider={mainnetProvider} />
+                ) : (
+                  ""
+                )
+              }
+            </Col>
+          </Row>
+        </div>
       </div>
-
-      {/* 🗺 Extra UI like gas price, eth price, faucet, and support: */}
-      <div style={{ position: "fixed", textAlign: "left", left: 0, bottom: 20, padding: 10 }}>
-        <Row align="middle" gutter={[4, 4]}>
-          <Col span={8}>
-            <Ramp price={price} address={address} networks={NETWORKS} />
-          </Col>
-
-          <Col span={8} style={{ textAlign: "center", opacity: 0.8 }}>
-            <GasGauge gasPrice={gasPrice} />
-          </Col>
-          <Col span={8} style={{ textAlign: "center", opacity: 1 }}>
-            <Button
-              onClick={() => {
-                window.open("https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA");
-              }}
-              size="large"
-              shape="round"
-            >
-              <span style={{ marginRight: 8 }} role="img" aria-label="support">
-                💬
-              </span>
-              Support
-            </Button>
-          </Col>
-        </Row>
-
-        <Row align="middle" gutter={[4, 4]}>
-          <Col span={24}>
-            {
-              /*  if the local provider has a signer, let's show the faucet:  */
-              faucetAvailable ? (
-                <Faucet localProvider={localProvider} price={price} ensProvider={mainnetProvider} />
-              ) : (
-                ""
-              )
-            }
-          </Col>
-        </Row>
-      </div>
-    </div>
+    </ServerBasedTransactionsProvider>
   );
 }
 

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -588,9 +588,10 @@ function App(props) {
         </Menu.Item>
       </Menu>
       <TransactionsProvider
-        providerType="p2p"
+        providerType="server"
         providerOptions={{
-          url: BACKEND_URL + readContracts[contractName]?.address + "_" + localProvider?._network.chainId,
+          serverUrl: BACKEND_URL,
+          chainId: localProvider?._network.chainId,
           address,
           contractAddress,
           ownerEvents,

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -588,9 +588,9 @@ function App(props) {
         </Menu.Item>
       </Menu>
       <TransactionsProvider
-        providerType="server"
+        providerType="p2p"
         providerOptions={{
-          url: BACKEND_URL + readContracts[contractName].address + "_" + localProvider._network.chainId,
+          url: BACKEND_URL + readContracts[contractName]?.address + "_" + localProvider?._network.chainId,
           address,
           contractAddress,
           ownerEvents,

--- a/packages/react-app/src/components/MultiSig/Owners.jsx
+++ b/packages/react-app/src/components/MultiSig/Owners.jsx
@@ -1,36 +1,24 @@
 import React, { useEffect } from "react";
 import { Select, List, Spin, Collapse } from "antd";
 import { Address } from "..";
+import { useOwners } from "../../hooks";
 
 const { Panel } = Collapse;
 
-export default function Owners({
-  ownerEvents,
-  signaturesRequired,
-  mainnetProvider,
-  blockExplorer
-}) {
-  const owners = new Set();
-  const prevOwners = new Set();
-  ownerEvents.forEach((ownerEvent) => {
-    if (ownerEvent.args.added) {
-      owners.add(ownerEvent.args.owner);
-      prevOwners.delete(ownerEvent.args.owner)
-    } else {
-      prevOwners.add(ownerEvent.args.owner)
-      owners.delete(ownerEvent.args.owner);
-    }
-  });
+export default function Owners({ ownerEvents, signaturesRequired, mainnetProvider, blockExplorer }) {
+  const { owners, previousOwners } = useOwners({ ownerEvents });
 
   return (
     <div>
-      <h2 style={{marginTop:32}}>Signatures Required: {signaturesRequired ? signaturesRequired.toNumber() :<Spin></Spin>}</h2>
+      <h2 style={{ marginTop: 32 }}>
+        Signatures Required: {signaturesRequired ? signaturesRequired.toNumber() : <Spin></Spin>}
+      </h2>
       <List
         header={<h2>Owners</h2>}
-        style={{maxWidth:400, margin:"auto", marginTop:32}}
+        style={{ maxWidth: 400, margin: "auto", marginTop: 32 }}
         bordered
         dataSource={[...owners]}
-        renderItem={(ownerAddress) => {
+        renderItem={ownerAddress => {
           return (
             <List.Item key={"owner_" + ownerAddress}>
               <Address
@@ -40,15 +28,18 @@ export default function Owners({
                 fontSize={24}
               />
             </List.Item>
-          )
+          );
         }}
       />
 
-      <Collapse collapsible={prevOwners.size == 0 ? "disabled" : ""} style={{maxWidth:400, margin:"auto", marginTop:10}}>
+      <Collapse
+        collapsible={previousOwners.length === 0 ? "disabled" : ""}
+        style={{ maxWidth: 400, margin: "auto", marginTop: 10 }}
+      >
         <Panel header="Previous Owners" key="1">
           <List
-            dataSource={[...prevOwners]}
-            renderItem={(prevOwnerAddress) => {
+            dataSource={previousOwners}
+            renderItem={prevOwnerAddress => {
               return (
                 <List.Item key={"owner_" + prevOwnerAddress}>
                   <Address
@@ -58,7 +49,7 @@ export default function Owners({
                     fontSize={24}
                   />
                 </List.Item>
-              )
+              );
             }}
           />
         </Panel>

--- a/packages/react-app/src/contexts/P2PTransactionsProvider.js
+++ b/packages/react-app/src/contexts/P2PTransactionsProvider.js
@@ -12,7 +12,11 @@ export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents,
   const { owners } = useOwners({ ownerEvents });
   const peerIds = owners?.filter(o => o !== address).map(ownerAddress => `${contractAddress}-${ownerAddress}`);
   const client = useP2P({ contractAddress, address });
+
+  // used to receive peer changes, object keyed by peerId with their state
   const [peerState, isConnected] = useReceivePeerState({ peerBrokerIds: peerIds, client });
+
+  // Used to broadcast our state changes
   const [state, setState, connections] = usePeerState({
     initialState: JSON.parse(localStorage.getItem(storageKey) || "{}"),
     client,
@@ -26,8 +30,13 @@ export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents,
     [setState, storageKey],
   );
 
+  /**
+   * The server based provider saves 1 tx at a time.
+   * P2P easiest implemtation is sharing entire state. Could move this to be messages based and align the two.
+   */
   const saveTransaction = useCallback(
     tx => {
+      console.log("P2P: Saving TX", tx);
       const newState = { ...state, [tx.hash]: tx };
       saveTransactions(newState);
     },
@@ -38,7 +47,7 @@ export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents,
     if (!peerState) {
       return;
     }
-    console.log(`P2P: Merging State`, [state, peerState]);
+    console.log(`P2P: Merging State`, { state, peerState });
     // Naive sync merge
     let changed = false;
     for (const peerTxs of Object.values(peerState)) {
@@ -59,6 +68,8 @@ export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents,
     if (changed) {
       console.log(`P2P: State updated from peer`, state);
       saveTransactions(state);
+    } else {
+      console.log("P2P: No changes merged");
     }
   }, [JSON.stringify(peerState), JSON.stringify(state)]);
 
@@ -68,7 +79,7 @@ export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents,
     }),
   );
   const value = {
-    transactions: state,
+    unvalidatedTransactions: Object.values(state),
     saveTransaction,
   };
 

--- a/packages/react-app/src/contexts/P2PTransactionsProvider.js
+++ b/packages/react-app/src/contexts/P2PTransactionsProvider.js
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useP2P, useReceivePeerState, usePeerState, useCurrentOwners } from "../hooks";
+import { PeersContext } from "./PeersContext";
+import { TransactionContext } from "./TransactionContext";
+
+export const P2PTransactionsProvider = ({ address, contractAddress, ownerEvents, children }) => {
+  const storageKey = `txns-${contractAddress}`;
+  const peerIds = useCurrentOwners({ ownerEvents })
+    ?.filter(o => o !== address)
+    .map(ownerAddress => `${contractAddress}-${ownerAddress}`);
+  const client = useP2P({ contractAddress, address });
+  const [peerState, isConnected] = useReceivePeerState({ peerBrokerIds: peerIds, client });
+  const [state, setState, connections] = usePeerState({
+    initialState: JSON.parse(localStorage.getItem(storageKey) || "{}"),
+    client,
+  });
+
+  const saveTransactions = txs => {
+    setState(txs);
+    localStorage.setItem(storageKey, JSON.stringify(txs));
+  };
+
+  useEffect(() => {
+    if (!peerState) {
+      return;
+    }
+    console.log(`P2P: Merging State`, [state, peerState]);
+    // Naive sync merge
+    let changed = false;
+    for (const peerTxs of Object.values(peerState)) {
+      for (const [id, tx] of Object.entries(peerTxs)) {
+        if (!state[id]) {
+          state[id] = tx;
+          changed = true;
+        } else {
+          for (const signature of Object.values(tx.signatures)) {
+            if (!state[id].signatures[signature.signer]) {
+              state[id].signatures[signature.signer] = signature;
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+    if (changed) {
+      console.log(`P2P: State updated from peer`, state);
+      saveTransactions(state);
+    }
+  }, [JSON.stringify(peerState), JSON.stringify(state)]);
+
+  const peers = Object.fromEntries(
+    peerIds.map(id => {
+      return [id.split("-")[1], Boolean(isConnected?.[id] || connections.find(c => c.peer === id))];
+    }),
+  );
+  const value = {
+    transactions: state,
+    saveTransactions,
+  };
+
+  return (
+    <PeersContext.Provider value={peers}>
+      <TransactionContext.Provider value={value}>{children}</TransactionContext.Provider>
+    </PeersContext.Provider>
+  );
+};

--- a/packages/react-app/src/contexts/PeersContext.js
+++ b/packages/react-app/src/contexts/PeersContext.js
@@ -1,0 +1,3 @@
+import { createContext, useContext } from "react";
+export const PeersContext = createContext();
+export const usePeers = () => useContext(PeersContext);

--- a/packages/react-app/src/contexts/ServerTransactionsProvider.js
+++ b/packages/react-app/src/contexts/ServerTransactionsProvider.js
@@ -6,12 +6,13 @@ import { TransactionContext } from "./TransactionContext";
 /**
  * Uses a remote server to store transactions
  */
-export const ServerTransactionsProvider = ({ url, children }) => {
+export const ServerTransactionsProvider = ({ serverUrl, chainId, contractAddress, children }) => {
   // Stale-While- Revalidate provides a way to refresh remote data in a local cache and
   // control how it is refreshed. This enables polling refresh as well as the standard triggers
+  const getUrl = serverUrl + contractAddress + "_" + chainId;
   const { data: transactions } = useSWR(
-    url,
-    async () => {
+    getUrl,
+    async url => {
       const { data } = await axios.get(url);
       return data;
     },
@@ -20,10 +21,10 @@ export const ServerTransactionsProvider = ({ url, children }) => {
 
   const saveTransaction = useCallback(
     async tx => {
-      await axios.post(url, tx);
-      await mutate(url);
+      await axios.post(serverUrl, tx);
+      await mutate(getUrl);
     },
-    [url],
+    [getUrl, serverUrl],
   );
 
   const value = {

--- a/packages/react-app/src/contexts/ServerTransactionsProvider.js
+++ b/packages/react-app/src/contexts/ServerTransactionsProvider.js
@@ -1,11 +1,10 @@
 import axios from "axios";
-import { createContext, useCallback, useContext } from "react";
+import { useCallback } from "react";
 import useSWR, { mutate } from "swr";
+import { TransactionContext } from "./TransactionContext";
 
-export const TransactionContext = createContext();
-
-export const ServerBasedTransactionsProvider = ({ url, children }) => {
-  // STale While Revalidate provides a way to refresh remote data in a local cache and
+export const ServerTransactionsProvider = ({ url, children }) => {
+  // Stale-While- Revalidate provides a way to refresh remote data in a local cache and
   // control how it is refreshed. This enables polling refresh as well as the standard triggers
   const { data: transactions } = useSWR(
     url,
@@ -31,4 +30,3 @@ export const ServerBasedTransactionsProvider = ({ url, children }) => {
 
   return <TransactionContext.Provider value={value}>{children}</TransactionContext.Provider>;
 };
-export const useTransactions = () => useContext(TransactionContext);

--- a/packages/react-app/src/contexts/ServerTransactionsProvider.js
+++ b/packages/react-app/src/contexts/ServerTransactionsProvider.js
@@ -3,6 +3,9 @@ import { useCallback } from "react";
 import useSWR, { mutate } from "swr";
 import { TransactionContext } from "./TransactionContext";
 
+/**
+ * Uses a remote server to store transactions
+ */
 export const ServerTransactionsProvider = ({ url, children }) => {
   // Stale-While- Revalidate provides a way to refresh remote data in a local cache and
   // control how it is refreshed. This enables polling refresh as well as the standard triggers
@@ -15,9 +18,9 @@ export const ServerTransactionsProvider = ({ url, children }) => {
     { refreshInterval: 3777 },
   );
 
-  const saveTransactions = useCallback(
-    async newTransactions => {
-      await axios.post(url, newTransactions);
+  const saveTransaction = useCallback(
+    async tx => {
+      await axios.post(url, tx);
       await mutate(url);
     },
     [url],
@@ -25,7 +28,7 @@ export const ServerTransactionsProvider = ({ url, children }) => {
 
   const value = {
     unvalidatedTransactions: transactions,
-    saveTransactions,
+    saveTransaction,
   };
 
   return <TransactionContext.Provider value={value}>{children}</TransactionContext.Provider>;

--- a/packages/react-app/src/contexts/TransactionContext.js
+++ b/packages/react-app/src/contexts/TransactionContext.js
@@ -1,0 +1,3 @@
+import { createContext, useContext } from "react";
+export const TransactionContext = createContext();
+export const useTransactions = () => useContext(TransactionContext);

--- a/packages/react-app/src/contexts/TransactionProvider.js
+++ b/packages/react-app/src/contexts/TransactionProvider.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+import { createContext, useCallback, useContext } from "react";
+import useSWR, { mutate } from "swr";
+
+export const TransactionContext = createContext();
+
+export const ServerBasedTransactionsProvider = ({ url, children }) => {
+  // STale While Revalidate provides a way to refresh remote data in a local cache and
+  // control how it is refreshed. This enables polling refresh as well as the standard triggers
+  const { data: transactions } = useSWR(
+    url,
+    async () => {
+      const { data } = await axios.get(url);
+      return data;
+    },
+    { refreshInterval: 3777 },
+  );
+
+  const saveTransactions = useCallback(
+    async newTransactions => {
+      await axios.post(url, newTransactions);
+      await mutate(url);
+    },
+    [url],
+  );
+
+  const value = {
+    unvalidatedTransactions: transactions,
+    saveTransactions,
+  };
+
+  return <TransactionContext.Provider value={value}>{children}</TransactionContext.Provider>;
+};
+export const useTransactions = () => useContext(TransactionContext);

--- a/packages/react-app/src/contexts/TransactionsProvider.js
+++ b/packages/react-app/src/contexts/TransactionsProvider.js
@@ -1,0 +1,15 @@
+import { P2PTransactionsProvider } from "./P2PTransactionsProvider";
+import { ServerTransactionsProvider } from "./ServerTransactionsProvider";
+
+export const TransactionsProvider = ({ providerType, providerOptions, children }) => {
+  if (providerType === "p2p") {
+    return <P2PTransactionsProvider {...providerOptions}>{children}</P2PTransactionsProvider>;
+  }
+
+  if (providerType === "server") {
+    return <ServerTransactionsProvider {...providerOptions}>{children}</ServerTransactionsProvider>;
+  }
+
+  console.warn(`Unknown transactions provider ${providerType}`);
+  return children;
+};

--- a/packages/react-app/src/contexts/index.js
+++ b/packages/react-app/src/contexts/index.js
@@ -1,0 +1,1 @@
+export * from "./TransactionProvider";

--- a/packages/react-app/src/contexts/index.js
+++ b/packages/react-app/src/contexts/index.js
@@ -1,1 +1,2 @@
-export * from "./TransactionProvider";
+export * from "./TransactionsProvider";
+export * from "./TransactionContext";

--- a/packages/react-app/src/hooks/index.js
+++ b/packages/react-app/src/hooks/index.js
@@ -2,3 +2,5 @@ export { default as useDebounce } from "./useDebounce";
 export { default as useLocalStorage } from "./useLocalStorage";
 export { default as useStaticJsonRPC } from "./useStaticJsonRPC";
 export * from "./useContractConfig";
+export * from "./p2p";
+export * from "./useOwners";

--- a/packages/react-app/src/hooks/p2p.js
+++ b/packages/react-app/src/hooks/p2p.js
@@ -2,6 +2,9 @@ import { useEffect, useState, useRef } from "react";
 import Peer from "peerjs";
 //inspo from https://github.com/madou/react-peer
 
+/**
+ * Receive changes to state from peers
+ */
 export const useReceivePeerState = ({ peerBrokerIds, client }) => {
   const [state, setState] = useState();
   const [isConnected, setIsConnected] = useState({});
@@ -46,6 +49,9 @@ export const useReceivePeerState = ({ peerBrokerIds, client }) => {
   return [state, isConnected];
 };
 
+/**
+ * Sends our state to our peers
+ */
 export const usePeerState = ({ initialState, client }) => {
   const [connections, setConnections] = useState([]);
   const [state, setState] = useState(initialState);

--- a/packages/react-app/src/hooks/p2p.js
+++ b/packages/react-app/src/hooks/p2p.js
@@ -1,0 +1,105 @@
+import { useEffect, useState, useRef } from "react";
+import Peer from "peerjs";
+//inspo from https://github.com/madou/react-peer
+
+export const useReceivePeerState = ({ peerBrokerIds, client }) => {
+  const [state, setState] = useState();
+  const [isConnected, setIsConnected] = useState({});
+
+  useEffect(() => {
+    if (!peerBrokerIds?.length) {
+      return;
+    }
+
+    if (!client) {
+      return;
+    }
+
+    console.log(`P2P: Connecting to peers: ${peerBrokerIds}`);
+
+    for (const id of peerBrokerIds) {
+      console.log(`P2P: Connecting to peer: ${id}`);
+      const connection = client.connect(id);
+
+      connection.on("open", () => {
+        console.log(`P2P: Connected to ${id}`);
+        connection.on("data", receivedData => {
+          console.log(`P2P: Received data from ${id}`, receivedData);
+          setState(prevState => ({ ...prevState, [id]: receivedData }));
+          setIsConnected(prevState => ({ ...prevState, [id]: true }));
+        });
+      });
+
+      connection.on("close", () => {
+        console.log(`P2P: Connection to ${id} closed`);
+        setIsConnected(prevState => ({ ...prevState, [id]: false }));
+      });
+
+      connection.on("error", err => console.error(`P2P: Error from ${id}`, err));
+    }
+
+    return () => {
+      setIsConnected({});
+    };
+  }, [JSON.stringify(peerBrokerIds), client]);
+
+  return [state, isConnected];
+};
+
+export const usePeerState = ({ initialState, client }) => {
+  const [connections, setConnections] = useState([]);
+  const [state, setState] = useState(initialState);
+  // We useRef to get around useLayoutEffect's closure only having access
+  // to the initial state since we only re-execute it if brokerId changes.
+  const stateRef = useRef(initialState);
+
+  useEffect(() => {
+    if (!client) {
+      return;
+    }
+    client.on("error", err => console.log(`P2P: Error`, err));
+
+    client.on("connection", conn => {
+      setConnections(prevState => [...prevState, conn]);
+
+      // We want to immediately send the newly connected peer the current data.
+      conn.on("open", () => {
+        console.log(`P2P: Connection from ${conn.peer}, sending state`);
+        conn.send(stateRef.current);
+      });
+    });
+  }, [client]);
+
+  return [
+    state,
+    newState => {
+      setState(newState);
+      stateRef.current = newState;
+      connections.forEach(conn => conn.send(newState));
+    },
+    connections,
+  ];
+};
+
+export const useP2P = ({ contractAddress, address }) => {
+  const [peer, setPeer] = useState(undefined);
+  useEffect(() => {
+    if (contractAddress && address) {
+      const brokerId = `${contractAddress}-${address}`;
+      console.log(`P2P: Connecting as ${brokerId}`);
+
+      const localPeer = new Peer(brokerId);
+      localPeer.on("error", err => console.error(`P2P: Error`, err));
+      localPeer.on("open", () => {
+        console.log(`P2P: Open`);
+        setPeer(localPeer);
+      });
+      return () => {
+        console.log(`P2P: Destroying`);
+        localPeer?.destroy();
+      };
+    }
+  }, [contractAddress, address]);
+
+  return peer;
+};

--- a/packages/react-app/src/hooks/useOwners.js
+++ b/packages/react-app/src/hooks/useOwners.js
@@ -1,18 +1,19 @@
 export const useOwners = ({ ownerEvents }) => {
   const events = ownerEvents?.sort((a, b) => a.blockNumber - b.blockNumber) || [];
   const { owners, previousOwners } = events.reduce(
-    ({ owners, previousOwners }, e) => {
-      if (e.added) {
-        owners[e.owner] = e;
-        delete previousOwners[e.owner];
+    (result, { args }) => {
+      const { owners, previousOwners } = result;
+      if (args.added) {
+        owners.add(args.owner);
+        previousOwners.delete(args.owner);
       } else {
-        previousOwners[e.owner] = e;
-        delete owners[e.owner];
+        previousOwners.add(args.owner);
+        owners.delete(args.owner);
       }
-      return owners;
+      return result;
     },
-    { owners: {}, previousOwners: {} },
+    { owners: new Set(), previousOwners: new Set() },
   );
 
-  return { owners: Object.keys(owners || {}), previousOwners: Object.keys(previousOwners || {}) };
+  return { owners: [...owners], previousOwners: [...previousOwners] };
 };

--- a/packages/react-app/src/hooks/useOwners.js
+++ b/packages/react-app/src/hooks/useOwners.js
@@ -1,5 +1,5 @@
 export const useOwners = ({ ownerEvents }) => {
-  const events = ownerEvents.sort((a, b) => a.blockNumber - b.blockNumber);
+  const events = ownerEvents?.sort((a, b) => a.blockNumber - b.blockNumber) || [];
   const { owners, previousOwners } = events.reduce(
     ({ owners, previousOwners }, e) => {
       if (e.added) {
@@ -14,5 +14,5 @@ export const useOwners = ({ ownerEvents }) => {
     { owners: {}, previousOwners: {} },
   );
 
-  return { owners: Object.keys(owners), previousOwners: Object.keys(previousOwners) };
+  return { owners: Object.keys(owners || {}), previousOwners: Object.keys(previousOwners || {}) };
 };

--- a/packages/react-app/src/hooks/useOwners.js
+++ b/packages/react-app/src/hooks/useOwners.js
@@ -1,0 +1,18 @@
+export const useOwners = ({ ownerEvents }) => {
+  const events = ownerEvents.sort((a, b) => a.blockNumber - b.blockNumber);
+  const { owners, previousOwners } = events.reduce(
+    ({ owners, previousOwners }, e) => {
+      if (e.added) {
+        owners[e.owner] = e;
+        delete previousOwners[e.owner];
+      } else {
+        previousOwners[e.owner] = e;
+        delete owners[e.owner];
+      }
+      return owners;
+    },
+    { owners: {}, previousOwners: {} },
+  );
+
+  return { owners: Object.keys(owners), previousOwners: Object.keys(previousOwners) };
+};

--- a/packages/react-app/src/views/CreateTransaction.jsx
+++ b/packages/react-app/src/views/CreateTransaction.jsx
@@ -1,19 +1,17 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useHistory } from "react-router-dom";
 import { Button, Input, Select, InputNumber, Space, Tooltip } from "antd";
-import { CodeOutlined } from '@ant-design/icons';
+import { CodeOutlined } from "@ant-design/icons";
 import { AddressInput, EtherInput, WalletConnectInput } from "../components";
 import TransactionDetailsModal from "../components/MultiSig/TransactionDetailsModal";
 import { parseExternalContractTransaction } from "../helpers";
 import { useLocalStorage } from "../hooks";
 import { ethers } from "ethers";
 import { parseEther } from "@ethersproject/units";
+import { useTransactions } from "../contexts/TransactionContext";
 const { Option } = Select;
 
-const axios = require("axios");
-
 export default function CreateTransaction({
-  poolServerUrl,
   contractName,
   contractAddress,
   mainnetProvider,
@@ -26,8 +24,8 @@ export default function CreateTransaction({
 }) {
   const history = useHistory();
 
-  const [methodName, setMethodName] = useLocalStorage("methodName", "transferFunds")
-  const [newSignaturesRequired, setNewSignaturesRequired] = useState(signaturesRequired)
+  const [methodName, setMethodName] = useLocalStorage("methodName", "transferFunds");
+  const [newSignaturesRequired, setNewSignaturesRequired] = useState(signaturesRequired);
   const [amount, setAmount] = useState("0");
   const [to, setTo] = useLocalStorage("to");
   const [customCallData, setCustomCallData] = useState("");
@@ -35,14 +33,15 @@ export default function CreateTransaction({
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [loading, setLoading] = useState(false);
   const [isWalletConnectTransaction, setIsWalletConnectTransaction] = useState(false);
+  const { saveTransaction } = useTransactions();
 
-  const [hasEdited, setHasEdited] = useState() //we want the signaturesRequired to update from the contract _until_ they edit it
+  const [hasEdited, setHasEdited] = useState(); //we want the signaturesRequired to update from the contract _until_ they edit it
 
-  useEffect(()=>{
-    if(!hasEdited){
-      setNewSignaturesRequired(signaturesRequired)
+  useEffect(() => {
+    if (!hasEdited) {
+      setNewSignaturesRequired(signaturesRequired);
     }
-  },[signaturesRequired])
+  }, [signaturesRequired, hasEdited]);
 
   const showModal = () => {
     setIsModalVisible(true);
@@ -56,10 +55,10 @@ export default function CreateTransaction({
     const getParsedTransaction = async () => {
       const parsedTransaction = await parseExternalContractTransaction(to, customCallData);
       setParsedCustomCallData(parsedTransaction);
-    }
+    };
 
     getParsedTransaction();
-  }, [customCallData]);
+  }, [customCallData, to]);
 
   const loadWalletConnectData = ({ to, value, data }) => {
     setTo(to);
@@ -75,12 +74,11 @@ export default function CreateTransaction({
 
   const createTransaction = async () => {
     try {
-
-      //a little security in the frontend just because 
-      if(newSignaturesRequired<1){
-        alert("signatures required must be >= 1")
-      }else{
-        setLoading(true)
+      //a little security in the frontend just because
+      if (newSignaturesRequired < 1) {
+        alert("signatures required must be >= 1");
+      } else {
+        setLoading(true);
 
         let callData;
         let executeToAddress;
@@ -88,7 +86,10 @@ export default function CreateTransaction({
           callData = methodName == "transferFunds" ? "0x" : customCallData;
           executeToAddress = to;
         } else {
-          callData = readContracts[contractName]?.interface?.encodeFunctionData(methodName, [to, newSignaturesRequired]);
+          callData = readContracts[contractName]?.interface?.encodeFunctionData(methodName, [
+            to,
+            newSignaturesRequired,
+          ]);
           executeToAddress = contractAddress;
         }
 
@@ -109,7 +110,7 @@ export default function CreateTransaction({
         console.log("isOwner: ", isOwner);
 
         if (isOwner) {
-          const res = await axios.post(poolServerUrl, {
+          await saveTransaction({
             chainId: localProvider._network.chainId,
             address: readContracts[contractName]?.address,
             nonce: nonce.toNumber(),
@@ -121,7 +122,6 @@ export default function CreateTransaction({
             signers: [recover],
           });
 
-          console.log("RESULT", res.data);
           setTimeout(() => {
             history.push("/pool");
             setLoading(false);
@@ -130,9 +130,7 @@ export default function CreateTransaction({
           console.log("ERROR, NOT OWNER.");
         }
       }
-
-
-    } catch(error) {
+    } catch (error) {
       console.log("Error: ", error);
       setLoading(false);
     }
@@ -140,7 +138,6 @@ export default function CreateTransaction({
 
   return (
     <div>
-
       <div style={{ border: "1px solid #cccccc", padding: 16, width: 400, margin: "auto", marginTop: 64 }}>
         <div style={{ margin: 8 }}>
           <div style={{ margin: 8, padding: 8 }}>
@@ -176,22 +173,22 @@ export default function CreateTransaction({
                 />
               </div>
               <div style={inputStyle}>
-                {(methodName == "addSigner" || methodName == "removeSigner") &&
+                {(methodName == "addSigner" || methodName == "removeSigner") && (
                   <InputNumber
                     style={{ width: "100%" }}
                     placeholder="New # of signatures required"
                     value={newSignaturesRequired}
-                    onChange={(value)=>{
-                      setNewSignaturesRequired(value)
-                      setHasEdited(true)
+                    onChange={value => {
+                      setNewSignaturesRequired(value);
+                      setHasEdited(true);
                     }}
                   />
-                }
-                {methodName == "customCallData" &&
+                )}
+                {methodName == "customCallData" && (
                   <>
                     <Input.Group compact>
                       <Input
-                        style={{ width: 'calc(100% - 31px)', marginBottom: 20 }}
+                        style={{ width: "calc(100% - 31px)", marginBottom: 20 }}
                         placeholder="Custom call data"
                         value={customCallData}
                         onChange={e => {
@@ -211,29 +208,19 @@ export default function CreateTransaction({
                       price={price}
                     />
                   </>
-                }
-                {(methodName == "transferFunds" || methodName == "customCallData") &&
-                  <EtherInput
-                    price={price}
-                    mode="USD"
-                    value={amount}
-                    onChange={setAmount}
-                  />
-                }
+                )}
+                {(methodName == "transferFunds" || methodName == "customCallData") && (
+                  <EtherInput price={price} mode="USD" value={amount} onChange={setAmount} />
+                )}
               </div>
               <Space style={{ marginTop: 32 }}>
-                <Button
-                  loading={loading}
-                  onClick={createTransaction}
-                  type="primary"
-                >
+                <Button loading={loading} onClick={createTransaction} type="primary">
                   Propose
                 </Button>
               </Space>
             </>
           )}
         </div>
-
       </div>
     </div>
   );

--- a/packages/react-app/src/views/Transactions.jsx
+++ b/packages/react-app/src/views/Transactions.jsx
@@ -41,6 +41,8 @@ export default function Transactions({
             const isOwner = await contract.isOwner(signer);
             if (signer && isOwner) {
               validSignatures.push({ signer, signature: tx.signatures[sig] });
+            } else {
+              console.warn(`Invalid TX`, tx);
             }
           }
 

--- a/packages/react-app/src/views/Transactions.jsx
+++ b/packages/react-app/src/views/Transactions.jsx
@@ -3,7 +3,7 @@ import { Button, List, Divider, Input, Card, DatePicker, Slider, Switch, Progres
 import { parseEther, formatEther } from "@ethersproject/units";
 import { ethers } from "ethers";
 import { TransactionListItem } from "../components";
-import { useTransactions } from "../contexts/TransactionProvider";
+import { useTransactions } from "../contexts/ServerTransactionsProvider";
 
 export default function Transactions({
   poolServerUrl,

--- a/packages/react-app/src/views/Transactions.jsx
+++ b/packages/react-app/src/views/Transactions.jsx
@@ -3,7 +3,7 @@ import { Button, List, Divider, Input, Card, DatePicker, Slider, Switch, Progres
 import { parseEther, formatEther } from "@ethersproject/units";
 import { ethers } from "ethers";
 import { TransactionListItem } from "../components";
-import { useTransactions } from "../contexts/ServerTransactionsProvider";
+import { useTransactions } from "../contexts";
 
 export default function Transactions({
   poolServerUrl,

--- a/packages/react-app/src/views/Transactions.jsx
+++ b/packages/react-app/src/views/Transactions.jsx
@@ -1,14 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Button, List, Divider, Input, Card, DatePicker, Slider, Switch, Progress, Spin } from "antd";
-import { ConsoleSqlOutlined, SyncOutlined } from "@ant-design/icons";
 import { parseEther, formatEther } from "@ethersproject/units";
 import { ethers } from "ethers";
-import { Address, AddressInput, Balance, Blockie, TransactionListItem } from "../components";
-import { usePoller } from "eth-hooks";
-
-const axios = require("axios");
-
-const DEBUG = false;
+import { TransactionListItem } from "../components";
+import { useTransactions } from "../contexts/TransactionProvider";
 
 export default function Transactions({
   poolServerUrl,
@@ -26,30 +21,30 @@ export default function Transactions({
   writeContracts,
   blockExplorer,
 }) {
-  const [transactions, setTransactions] = useState();
-  usePoller(() => {
-    const getTransactions = async () => {
-      const res = await axios.get(
-        poolServerUrl + readContracts[contractName].address + "_" + localProvider._network.chainId,
-      );
-
-      console.log("backend stuff res", res.data);
-
+  const { unvalidatedTransactions, saveTransactions } = useTransactions();
+  const [transactions, setTransactions] = useState([]);
+  const contract = readContracts[contractName];
+  useEffect(() => {
+    console.log("Validate triggered");
+    const validateTransactions = async () => {
+      if (!unvalidatedTransactions) {
+        return;
+      }
       const newTransactions = [];
-      for (const i in res.data) {
-        console.log("backend stuff res.data[i]", res.data[i]);
-        const thisNonce = ethers.BigNumber.from(res.data[i].nonce);
+      for (const tx of Object.values(unvalidatedTransactions)) {
+        console.log("backend stuff tx", tx);
+        const thisNonce = ethers.BigNumber.from(tx.nonce);
         if (thisNonce && nonce && thisNonce.gte(nonce)) {
           const validSignatures = [];
-          for (const sig in res.data[i].signatures) {
-            const signer = await readContracts[contractName].recover(res.data[i].hash, res.data[i].signatures[sig]);
-            const isOwner = await readContracts[contractName].isOwner(signer);
+          for (const sig in tx.signatures) {
+            const signer = await contract.recover(tx.hash, tx.signatures[sig]);
+            const isOwner = await contract.isOwner(signer);
             if (signer && isOwner) {
-              validSignatures.push({ signer, signature: res.data[i].signatures[sig] });
+              validSignatures.push({ signer, signature: tx.signatures[sig] });
             }
           }
 
-          const update = { ...res.data[i], validSignatures };
+          const update = { ...tx, validSignatures };
           newTransactions.push(update);
         }
       }
@@ -58,8 +53,9 @@ export default function Transactions({
 
       setTransactions(newTransactions);
     };
-    if (readContracts[contractName]) getTransactions();
-  }, 3777);
+
+    validateTransactions().catch(e => console.error("Error validating transactions", e));
+  }, [contract, unvalidatedTransactions, nonce]);
 
   const getSortedSigList = async (allSigs, newHash) => {
     const sigList = [];
@@ -114,69 +110,75 @@ export default function Transactions({
               readContracts={readContracts}
               contractName={contractName}
             >
-              <div style={{padding:16}}>
-              <span style={{padding:4}}>
-                {item.signatures.length}/{signaturesRequired.toNumber()} {hasSigned ? "✅" : ""}
-              </span>
-              <span style={{padding:4}}>
-                <Button
-                  type="secondary"
-                  onClick={async () => {
-                    const newHash = await readContracts[contractName].getTransactionHash(
-                      item.nonce,
-                      item.to,
-                      parseEther("" + parseFloat(item.amount).toFixed(12)),
-                      item.data,
-                    );
-
-                    const signature = await userSigner?.signMessage(ethers.utils.arrayify(newHash));
-                    const recover = await readContracts[contractName].recover(newHash, signature);
-                    const isOwner = await readContracts[contractName].isOwner(recover);
-                    if (isOwner) {
-                      const [finalSigList, finalSigners] = await getSortedSigList(
-                        [...item.signatures, signature],
-                        newHash,
+              <div style={{ padding: 16 }}>
+                <span style={{ padding: 4 }}>
+                  {item.signatures.length}/{signaturesRequired.toNumber()} {hasSigned ? "✅" : ""}
+                </span>
+                <span style={{ padding: 4 }}>
+                  <Button
+                    type="secondary"
+                    onClick={async () => {
+                      const newHash = await readContracts[contractName].getTransactionHash(
+                        item.nonce,
+                        item.to,
+                        parseEther("" + parseFloat(item.amount).toFixed(12)),
+                        item.data,
                       );
-                      const res = await axios.post(poolServerUrl, {
-                        ...item,
-                        signatures: finalSigList,
-                        signers: finalSigners,
-                      });
-                    }
-                  }}
-                >
-                  Sign
-                </Button>
-                <Button
-                  key={item.hash}
-                  type={hasEnoughSignatures ? "primary" : "secondary"}
-                  onClick={async () => {
-                    const newHash = await readContracts[contractName].getTransactionHash(
-                      item.nonce,
-                      item.to,
-                      parseEther("" + parseFloat(item.amount).toFixed(12)),
-                      item.data,
-                    );
 
-                    const [finalSigList, finalSigners] = await getSortedSigList(item.signatures, newHash);
+                      const signature = await userSigner?.signMessage(ethers.utils.arrayify(newHash));
+                      const recover = await readContracts[contractName].recover(newHash, signature);
+                      const isOwner = await readContracts[contractName].isOwner(recover);
+                      if (isOwner) {
+                        const [finalSigList, finalSigners] = await getSortedSigList(
+                          [...item.signatures, signature],
+                          newHash,
+                        );
+                        await saveTransactions({
+                          ...item,
+                          signatures: finalSigList,
+                          signers: finalSigners,
+                        });
+                      }
+                    }}
+                  >
+                    Sign
+                  </Button>
+                  <Button
+                    key={item.hash}
+                    type={hasEnoughSignatures ? "primary" : "secondary"}
+                    onClick={async () => {
+                      const newHash = await readContracts[contractName].getTransactionHash(
+                        item.nonce,
+                        item.to,
+                        parseEther("" + parseFloat(item.amount).toFixed(12)),
+                        item.data,
+                      );
 
-                    console.log("writeContracts: ", item.to, parseEther("" + parseFloat(item.amount).toFixed(12)), item.data, finalSigList);
+                      const [finalSigList, finalSigners] = await getSortedSigList(item.signatures, newHash);
 
-                    tx(
-                      writeContracts[contractName].executeTransaction(
+                      console.log(
+                        "writeContracts: ",
                         item.to,
                         parseEther("" + parseFloat(item.amount).toFixed(12)),
                         item.data,
                         finalSigList,
-                      ),
-                    );
-                  }}
-                >
-                  Exec
-                </Button>
-              </span>
-            </div>
-          </TransactionListItem>
+                      );
+
+                      tx(
+                        writeContracts[contractName].executeTransaction(
+                          item.to,
+                          parseEther("" + parseFloat(item.amount).toFixed(12)),
+                          item.data,
+                          finalSigList,
+                        ),
+                      );
+                    }}
+                  >
+                    Exec
+                  </Button>
+                </span>
+              </div>
+            </TransactionListItem>
           );
         }}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -20523,6 +20523,11 @@ swarm-js@^0.1.40:
     tar "^4.0.2"
     xhr-request "^1.0.1"
 
+swr@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
+  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+
 symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,13 +2907,6 @@
     "@svgr/plugin-svgo" "^5.4.0"
     loader-utils "^2.0.0"
 
-"@swc/helpers@^0.3.13":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.13.tgz#b9af856aaa3804fefdd1544632dde35b7b6ff978"
-  integrity sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==
-  dependencies:
-    tslib "^2.4.0"
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -3233,7 +3226,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
   integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
 
-"@types/node@^10.0.3":
+"@types/node@^10.0.3", "@types/node@^10.14.33":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
@@ -9727,10 +9720,15 @@ eventemitter3@4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
-eventemitter3@4.0.7, eventemitter3@^4.0.0, eventemitter3@^4.0.7:
+eventemitter3@4.0.7, eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventemitter3@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 events@1.1.1:
   version "1.1.1"
@@ -16476,13 +16474,13 @@ peerjs-js-binarypack@1.0.1:
   resolved "https://registry.yarnpkg.com/peerjs-js-binarypack/-/peerjs-js-binarypack-1.0.1.tgz#80fa2b61c794a6b16d64253700405e476ada29be"
   integrity sha512-N6aeia3NhdpV7kiGxJV5xQiZZCVEEVjRz2T2C6UZQiBkHWHzUv/oWA4myQLcwBwO8LUoR1KWW5oStvwVesmfCg==
 
-peerjs@1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/peerjs/-/peerjs-1.4.4.tgz#a0a822038ea6c7b61c598714634f5b2c30db09e0"
-  integrity sha512-CGZDYa++gtDmpSP1s0o5/zYevmIrFm41Urqw3TE/ngW8tBwsvlU3BiGK1H/jYUhUj/8wOlvSokw5WTtfJwqeyg==
+peerjs@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/peerjs/-/peerjs-1.3.2.tgz#25cf5e8e7c143b41c2a5760a3d6ec0bb0bbb94d9"
+  integrity sha512-+PHfmsC7QGUU8Ye3OLi6tKQZGPCNy7QatUVNw4JtE8alkguF3+DdO5W0bzepqP2OtE9FqH/ltXt37qyvHw2CqA==
   dependencies:
-    "@swc/helpers" "^0.3.13"
-    eventemitter3 "^4.0.7"
+    "@types/node" "^10.14.33"
+    eventemitter3 "^3.1.2"
     peerjs-js-binarypack "1.0.1"
     webrtc-adapter "^7.7.1"
 
@@ -21126,11 +21124,6 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
-
-tslib@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsort@0.0.1:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,6 +2907,13 @@
     "@svgr/plugin-svgo" "^5.4.0"
     loader-utils "^2.0.0"
 
+"@swc/helpers@^0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.13.tgz#b9af856aaa3804fefdd1544632dde35b7b6ff978"
+  integrity sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -9720,7 +9727,7 @@ eventemitter3@4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
 
-eventemitter3@4.0.7, eventemitter3@^4.0.0:
+eventemitter3@4.0.7, eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -16464,6 +16471,21 @@ peer-info@~0.15.1:
     peer-id "~0.12.2"
     unique-by "^1.0.0"
 
+peerjs-js-binarypack@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/peerjs-js-binarypack/-/peerjs-js-binarypack-1.0.1.tgz#80fa2b61c794a6b16d64253700405e476ada29be"
+  integrity sha512-N6aeia3NhdpV7kiGxJV5xQiZZCVEEVjRz2T2C6UZQiBkHWHzUv/oWA4myQLcwBwO8LUoR1KWW5oStvwVesmfCg==
+
+peerjs@1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/peerjs/-/peerjs-1.4.4.tgz#a0a822038ea6c7b61c598714634f5b2c30db09e0"
+  integrity sha512-CGZDYa++gtDmpSP1s0o5/zYevmIrFm41Urqw3TE/ngW8tBwsvlU3BiGK1H/jYUhUj/8wOlvSokw5WTtfJwqeyg==
+  dependencies:
+    "@swc/helpers" "^0.3.13"
+    eventemitter3 "^4.0.7"
+    peerjs-js-binarypack "1.0.1"
+    webrtc-adapter "^7.7.1"
+
 pem-jwk@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz#1c5bb264612fc391340907f5c1de60c06d22f085"
@@ -21105,6 +21127,11 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tsort@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tsort/-/tsort-0.0.1.tgz#e2280f5e817f8bf4275657fd0f9aebd44f5a2786"
@@ -22366,7 +22393,7 @@ webpack@4.44.2:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webrtc-adapter@^7.2.1:
+webrtc-adapter@^7.2.1, webrtc-adapter@^7.7.1:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz#b2c227a6144983b35057df67bd984a7d4bfd17f1"
   integrity sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==


### PR DESCRIPTION
This adds the concept of Transaction Context Providers to allow for different mechanisms for sharing transaction proposals. It includes the current server based solution, which has been converted to use [SWR](https://swr.vercel.app/). A vercel library that more efficiently maintains remote state as local cache (i.e. polling, refreshing etc of a remote data endpoint)

It also introduces a P2P provider which allows for more decentralised sharing of transactions (at the expense of requiring owners to propose transactions whilst sufficient parties are online i.e. its not great for async workflows). It makes use of [PeerJS](https://peerjs.com/) who provide public servers for connecting peers. 

The basic workfow of P2P is
- Attempt to connect to all owners (peerid is contract address + wallet address)
- On connection share your transaction state
- On receive of remote state, merge with local state 
- On change of state, share with all connected peers

Can be merged as is, but in draft to discuss
- How should we enable swapping between backends?
  - Could toggle like dark mode, but requires communication between all owners to do so
  - Could bake a default into contract (bit more drastic)  
- My original implementation shows connected state on the owners list via a little 🌐 or 🚫 
  - Should we add this? It's a little leaky as server provider doesn't need.
  - Does it make more sense on propose? Or on transaction screen? instead of on owners list 
