### PR TITLE
Simulate transactions on Tenderly

### DIFF
--- a/packages/react-app/src/components/TenderlySimulation.jsx
+++ b/packages/react-app/src/components/TenderlySimulation.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { Spin } from "antd";
+import axios from "axios";
+
+const { BigNumber, ethers } = require("ethers");
+
+// set up your access-key, if you don't have one or you want to generate new one follow next link
+// https://dashboard.tenderly.co/account/authorization
+
+// Create a .env file in the react-app folder with the credentials
+//REACT_APP_TENDERLY_USER = ""
+//REACT_APP_TENDERLY_PROJECT = ""
+//REACT_APP_TENDERLY_ACCESS_KEY = ""
+
+const TENDERLY_USER = process.env.REACT_APP_TENDERLY_USER;
+const TENDERLY_PROJECT = process.env.REACT_APP_TENDERLY_PROJECT;
+const TENDERLY_ACCESS_KEY = process.env.REACT_APP_TENDERLY_ACCESS_KEY;
+
+const SIMULATE_URL = `https://api.tenderly.co/api/v1/account/${TENDERLY_USER}/project/${TENDERLY_PROJECT}/simulate`;
+const OPTS = {
+  headers: {
+    'X-Access-Key': TENDERLY_ACCESS_KEY
+  }
+}
+
+export default function TenderlySimulation({ params, address, multiSigWallet}) {
+  const [simulated, setSimulated] = useState(false);
+  const [simulationFailed, setSimulationFailed] = useState(false);
+  const [simulationUnexpectedError, setSimulationUnexpectedError] = useState(false);
+  const [simulationId, setSimulationId] = useState();
+
+  useEffect(()=> {
+    const simulateTransaction = async () => {
+      try {
+        if (!params || !address || !multiSigWallet) {
+          return;
+        }
+
+        const value = params.amount ? ethers.utils.parseEther("" + parseFloat(params.amount).toFixed(12)) : "0x00";
+        const txData = (params.data && params.data != "0x") ? params.data : "0x";
+        let data = multiSigWallet.interface.encodeFunctionData("executeTransaction", [params.to, value, txData, params.signatures]);
+
+        const body = {
+          // standard TX fields
+          "network_id": params.chainId,
+          "from": address,
+          "to": multiSigWallet.address,
+          "input": data,
+          //"gas": 61606000,
+          //"gas_price": "0",
+          //"value": params.amount ? ethers.utils.parseEther(params.amount.toString()).toString() : "0", Let's keep this here to remember the hours long debugging
+          "value": "0",
+          // simulation config (tenderly specific)
+          "save_if_fails": true,
+          "save": true,
+          //"simulation_type": "quick"
+        }
+      
+        const resp = await axios.post(SIMULATE_URL, body, OPTS);
+
+        if (resp.data.simulation.status === false) {
+          setSimulationFailed(true);
+        }
+
+        setSimulationId(resp.data.simulation.id);
+        setSimulated(true);
+      }
+      catch(error) {
+        setSimulationUnexpectedError(true);
+        console.error("simulateTransaction", error)
+      }
+    }
+
+    simulateTransaction();
+  },[]);
+
+  return (
+    <div>
+       <div style={{ textAlign: "center"}}>
+          {!simulated && !simulationUnexpectedError && <>Simulating on Tenderly... <Spin/></>}
+          {simulated && simulationId && <>Simulating on <a target="_blank" rel="noopener noreferrer" href={`https://dashboard.tenderly.co/public/${TENDERLY_USER}/${TENDERLY_PROJECT}/simulator/${simulationId}`}>Tenderly</a> {!simulationFailed ? "was successful!" : "has failed!"}</>}
+          {simulationUnexpectedError && <>Couldn't simulate on <a target="_blank" rel="noopener noreferrer" href="https://tenderly.co/">Tenderly</a> because of an unexpected error.</>}
+       </div>
+    </div>
+  );
+}

--- a/packages/react-app/src/components/index.js
+++ b/packages/react-app/src/components/index.js
@@ -22,6 +22,7 @@ export { default as NetworkDisplay } from "./NetworkDisplay";
 export { default as FaucetHint } from "./FaucetHint";
 export { default as NetworkSwitch } from "./NetworkSwitch";
 export { default as MultiAddressInput } from "./MultiAddressInput";
+export { default as TenderlySimulation } from "./TenderlySimulation";
 export { default as TokenSelect } from "./TokenSelect";
 export { default as WalletConnectInput } from "./WalletConnectInput";
 

--- a/packages/react-app/src/views/Transactions.jsx
+++ b/packages/react-app/src/views/Transactions.jsx
@@ -3,7 +3,7 @@ import { Button, List, Spin } from "antd";
 import { usePoller } from "eth-hooks";
 import { ethers } from "ethers";
 import { useState } from "react";
-import { TransactionListItem } from "../components";
+import { TransactionListItem, TenderlySimulation } from "../components";
 import { useThemeSwitcher } from "react-css-theme-switcher";
 
 const axios = require("axios");
@@ -240,6 +240,7 @@ export default function Transactions({
                       </Button>
                     </div>
                   </div>
+                  <TenderlySimulation params={item} address={address} multiSigWallet={readContracts["MultiSigWallet"]}/>
                 </TransactionListItem>
               </div>
             );


### PR DESCRIPTION
This is just the first prototype.
It's ugly and it doesn't really make sense to simulate before we have enough signatures.
On the other hand it's really cool that we can simulate e.g. a wallet connect token swap, or validate if the mulitisigWallet has enough eth for the transfer.

.env file is needed with Tenderly credentials.

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/1397179/186657975-afb72b7c-f8e8-4273-9c9d-fb3e71940bf3.png">
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/1397179/186658078-b6eee245-9733-490f-b2c7-a4e5fe860334.png">
<img width="1384" alt="image" src="https://user-images.githubusercontent.com/1397179/186658169-63a1a727-05a4-4e1a-84a2-8b97e56afffb.png">

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/1397179/186658893-9c11c237-16d9-4cfc-a10a-bfaffd582275.png">

