### PR TITLE
Minor Contract Optimisations

### DIFF
--- a/packages/hardhat/contracts/MultiSigFactory.sol
+++ b/packages/hardhat/contracts/MultiSigFactory.sol
@@ -65,7 +65,6 @@ contract MultiSigFactory {
     }
 
     function create2(
-        uint256 _chainId,
         address[] calldata _owners,
         uint256 _signaturesRequired,
         string calldata _name
@@ -95,7 +94,7 @@ contract MultiSigFactory {
         /**----------------------
          * init remaining values
          * ---------------------*/
-        multiSig.init(_chainId, _owners, _signaturesRequired);
+        multiSig.init(_owners, _signaturesRequired);
 
         multiSigs.push(multiSig);
         existsMultiSig[address(multiSig_address)] = true;

--- a/packages/hardhat/contracts/MultiSigWallet.sol
+++ b/packages/hardhat/contracts/MultiSigWallet.sol
@@ -21,7 +21,7 @@ error TX_FAILED();
 
 contract MultiSigWallet {
     using ECDSA for bytes32;
-    MultiSigFactory private multiSigFactory;
+    MultiSigFactory private immutable multiSigFactory;
     uint256 public constant factoryVersion = 1; // <---- set the factory version for backword compatiblity for future contract updates
 
     event Deposit(address indexed sender, uint256 amount, uint256 balance);
@@ -81,7 +81,6 @@ contract MultiSigWallet {
     }
 
     function init(
-        uint256 _chainId,
         address[] calldata _owners,
         uint256 _signaturesRequired
     ) public payable onlyFactory onlyValidSignaturesRequired {
@@ -100,7 +99,7 @@ contract MultiSigWallet {
             }
         }
 
-        chainId = _chainId;
+        chainId = block.chainid;
     }
 
     function addSigner(address newSigner, uint256 newSignaturesRequired)

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^8.2.0",
     "ethereum-waffle": "^3.1.1",
     "ethers": "^5.4.4",
-    "hardhat": "2.6.0",
+    "hardhat": "2.11.2",
     "hardhat-deploy": "^0.9.0",
     "hardhat-gas-reporter": "^1.0.4",
     "hardhat-abi-exporter": "^2.8.0",

--- a/packages/hardhat/test/MultiSigWalletTest.js
+++ b/packages/hardhat/test/MultiSigWalletTest.js
@@ -20,7 +20,6 @@ describe("MultiSigWallet Test", () => {
     MultiSigFactory = await MultiSigFactoryContractFactory.deploy();
 
     await MultiSigFactory.create2(
-      CHAIN_ID,
       [owner.address],
       signatureRequired,
       CONTRACT_NAME
@@ -281,7 +280,6 @@ describe("MultiSigWallet Test", () => {
     it("Transaction reverted: Invalid MultiSigWallet, more signatures required than signers", async () => {
       await expect(
         MultiSigFactory.create2(
-          CHAIN_ID,
           [owner.address],
           2,
           CONTRACT_NAME + "Some random string so the names won't collide?"

--- a/packages/react-app/src/components/MultiSig/CreateMultiSigModal.jsx
+++ b/packages/react-app/src/components/MultiSig/CreateMultiSigModal.jsx
@@ -182,7 +182,7 @@ function CreateMultiSigModal({
         //   value: ethers.utils.parseEther("" + parseFloat(amount).toFixed(12)),
         // }
         // create 2
-        writeContracts[contractName].create2(selectedChainId, owners, signaturesRequired, currentWalletName, {
+        writeContracts[contractName].create2(owners, signaturesRequired, currentWalletName, {
           value: ethers.utils.parseEther("" + parseFloat(amount).toFixed(12)),
         }),
         async update => {


### PR DESCRIPTION
Minor Optimisations & Test Fixes

Notes
-  the modifier in the wallet contract.is used in methods where we need to check in the post state so I think we can leave the modifier as it is
-  I don't see any substantial benefit in replacing the array with the enum address set so I think we can leave that as it is too
